### PR TITLE
Balance sensor

### DIFF
--- a/custom_components/launtel/__init__.py
+++ b/custom_components/launtel/__init__.py
@@ -44,13 +44,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         locid: Optional[str] = None
         plans_mapping: dict[int, dict[str, object]] = {}
         balance: Optional[float] = None
+        estimated_days_remaining: Optional[int] = None
 
         try:
-            # Fetch services and balance in parallel for efficiency
+            # Fetch services, balance, and estimated days remaining in parallel for efficiency
             services_task = client.async_get_services()
             balance_task = client.async_get_balance()
+            days_task = client.async_get_estimated_days_remaining()
             
-            services, balance = await asyncio.gather(services_task, balance_task, return_exceptions=True)
+            services, balance, estimated_days_remaining = await asyncio.gather(
+                services_task, balance_task, days_task, return_exceptions=True
+            )
             
             # Handle services result
             if isinstance(services, Exception):
@@ -61,6 +65,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if isinstance(balance, Exception):
                 _LOGGER.debug("Balance fetch error: %s", balance)
                 balance = None
+            
+            # Handle estimated days remaining result
+            if isinstance(estimated_days_remaining, Exception):
+                _LOGGER.debug("Estimated days remaining fetch error: %s", estimated_days_remaining)
+                estimated_days_remaining = None
             
             svc = next((s for s in services if s.service_id == service_id), None)
 
@@ -134,6 +143,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "change_in_progress": change_in_progress,
             "service_speed_label": svc.speed_label if svc else None,
             "account_balance": balance,
+            "estimated_days_remaining": estimated_days_remaining,
         }
 
         # Remember last known good service card

--- a/custom_components/launtel/api.py
+++ b/custom_components/launtel/api.py
@@ -268,70 +268,34 @@ class LauntelClient:
         
         balance = None
         
-        # Look for the specific balance structure in the Launtel portal
-        # Target: <dt>Current Balance</dt><dd><span class="text-success">+$112.65</span></dd>
-        current_balance_dt = soup.find("dt", string=re.compile(r"Current\s+Balance", re.I))
-        if current_balance_dt:
-            dd_balance = current_balance_dt.find_next("dd")
+        # Look for the specific current balance structure
+        # Target: <dt>Current Balance</dt><dd><span>+$112.65</span></dd>
+        # Note: dt may contain nested HTML elements, so we need to search by text content
+        all_dts = soup.find_all("dt")
+        balance_dt = None
+        for dt in all_dts:
+            if re.search(r"Current\s+Balance", dt.get_text(), re.I):
+                balance_dt = dt
+                break
+        
+        if balance_dt:
+            dd_balance = balance_dt.find_next("dd")
             if dd_balance:
                 # Look for the balance span within the dd element
                 balance_span = dd_balance.find("span")
                 if balance_span:
                     balance_text = balance_span.get_text(strip=True)
                     
-                    # Extract numeric value from text like "+$112.65" or "-$50.00"
+                    # Extract numeric value from text like '+$112.65' or '-$50.00'
                     balance_match = re.search(r'([\+\-]?)\$?([0-9,]+\.?[0-9]*)', balance_text)
                     if balance_match:
                         try:
                             sign = balance_match.group(1)
                             balance_str = balance_match.group(2).replace(',', '')
                             balance = float(balance_str)
-                            
-                            # Handle negative balances
-                            if sign == '-':
-                                balance = -balance
+                            balance = -balance if sign == '-' else balance
                         except (ValueError, AttributeError):
                             balance = None
-        
-        # Fallback: look for balance card structure
-        if balance is None:
-            balance_card = soup.find("div", class_="card-balance")
-            if balance_card:
-                balance_dd = balance_card.find("dd")
-                if balance_dd:
-                    balance_span = balance_dd.find("span")
-                    if balance_span:
-                        balance_text = balance_span.get_text(strip=True)
-                        
-                        balance_match = re.search(r'([\+\-]?)\$?([0-9,]+\.?[0-9]*)', balance_text)
-                        if balance_match:
-                            try:
-                                sign = balance_match.group(1)
-                                balance_str = balance_match.group(2).replace(',', '')
-                                balance = float(balance_str)
-                                
-                                if sign == '-':
-                                    balance = -balance
-                            except (ValueError, AttributeError):
-                                balance = None
-        
-        # Final fallback: search for "Current Balance" text pattern in page
-        if balance is None:
-            page_text = soup.get_text()
-            
-            # Look for "Current Balance +$112.65" pattern
-            balance_pattern = r'Current\s+Balance[:\s]*([\+\-]?)\$?([0-9,]+\.?[0-9]*)'
-            match = re.search(balance_pattern, page_text, re.IGNORECASE)
-            if match:
-                try:
-                    sign = match.group(1)
-                    balance_str = match.group(2).replace(',', '')
-                    balance = float(balance_str)
-                    
-                    if sign == '-':
-                        balance = -balance
-                except (ValueError, AttributeError):
-                    balance = None
         
         return balance
 

--- a/custom_components/launtel/api.py
+++ b/custom_components/launtel/api.py
@@ -334,3 +334,41 @@ class LauntelClient:
                     balance = None
         
         return balance
+
+    async def async_get_estimated_days_remaining(self) -> Optional[int]:
+        """Get the estimated days remaining from the services page."""
+        await self._ensure_login()
+        resp = await self._session.get(BASE_URL / "services")
+        resp.raise_for_status()
+        html = await resp.text()
+        soup = BeautifulSoup(html, "html.parser")
+        
+        days_remaining = None
+        
+        # Look for the specific estimated days remaining structure
+        # Target: <dt>Estimated Days Remaining ... </dt><dd><span class="text-success">27</span></dd>
+        # Note: dt may contain nested HTML elements, so we need to search by text content
+        all_dts = soup.find_all("dt")
+        days_dt = None
+        for dt in all_dts:
+            if re.search(r"Estimated\s+Days\s+Remaining", dt.get_text(), re.I):
+                days_dt = dt
+                break
+        
+        if days_dt:
+            dd_days = days_dt.find_next("dd")
+            if dd_days:
+                # Look for the days span within the dd element
+                days_span = dd_days.find("span")
+                if days_span:
+                    days_text = days_span.get_text(strip=True)
+                    
+                    # Extract numeric value from text like "27"
+                    days_match = re.search(r'(\d+)', days_text)
+                    if days_match:
+                        try:
+                            days_remaining = int(days_match.group(1))
+                        except (ValueError, AttributeError):
+                            days_remaining = None
+        
+        return days_remaining

--- a/custom_components/launtel/button.py
+++ b/custom_components/launtel/button.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data["coordinator"]
+
+    entities = [
+        LauntelRefreshButton(coordinator, entry),
+    ]
+    async_add_entities(entities)
+
+
+class LauntelRefreshButton(CoordinatorEntity, ButtonEntity):
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:refresh"
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        svc = coordinator.data.get("service")
+        title = svc.title if svc else entry.title
+        self._attr_name = f"{title} refresh"
+        self._attr_unique_id = f"{entry.data['service_id']}_refresh"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        svc = self.coordinator.data.get("service")
+        name = svc.title if svc else self._entry.title
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self._entry.data["service_id"]))},
+            name=name,
+            manufacturer="Launtel",
+            model="Internet Service",
+        )
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self.coordinator.async_request_refresh()

--- a/custom_components/launtel/const.py
+++ b/custom_components/launtel/const.py
@@ -9,4 +9,4 @@ CONF_PASSWORD = "password"
 CONF_SERVICE_ID = "service_id"
 
 # Platforms provided by this integration (pause/unpause removed)
-PLATFORMS = ["select", "sensor"]
+PLATFORMS = ["button", "select", "sensor"]

--- a/custom_components/launtel/sensor.py
+++ b/custom_components/launtel/sensor.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.const import CURRENCY_DOLLAR
 
 from .const import DOMAIN
 
@@ -16,8 +17,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
 
-    entity = LauntelCurrentPlanSensor(coordinator, entry)
-    async_add_entities([entity])
+    entities = [
+        LauntelCurrentPlanSensor(coordinator, entry),
+        LauntelBalanceSensor(coordinator, entry),
+    ]
+    async_add_entities(entities)
 
 
 class LauntelCurrentPlanSensor(CoordinatorEntity, SensorEntity):
@@ -72,4 +76,49 @@ class LauntelCurrentPlanSensor(CoordinatorEntity, SensorEntity):
             "options": list(data.get("options", [])),
             "plans": plans_serializable,
         }
+        return attrs
+
+
+class LauntelBalanceSensor(CoordinatorEntity, SensorEntity):
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:currency-usd"
+    _attr_device_class = SensorDeviceClass.MONETARY
+    _attr_native_unit_of_measurement = CURRENCY_DOLLAR
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        svc = coordinator.data.get("service")
+        title = svc.title if svc else entry.title
+        self._attr_name = f"{title} balance"
+        self._attr_unique_id = f"{entry.data['service_id']}_account_balance"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        svc = self.coordinator.data.get("service")
+        name = svc.title if svc else self._entry.title
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self._entry.data["service_id"]))},
+            name=name,
+            manufacturer="Launtel",
+            model="Internet Service",
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        return self.coordinator.data.get("account_balance")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        balance = self.coordinator.data.get("account_balance")
+        attrs: dict[str, Any] = {
+            "last_updated": self.coordinator.last_update_success,
+        }
+        
+        if balance is not None:
+            attrs.update({
+                "balance_status": "credit" if balance >= 0 else "debt",
+                "formatted_balance": f"${abs(balance):.2f}",
+            })
+        
         return attrs

--- a/custom_components/launtel/sensor.py
+++ b/custom_components/launtel/sensor.py
@@ -20,6 +20,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     entities = [
         LauntelCurrentPlanSensor(coordinator, entry),
         LauntelBalanceSensor(coordinator, entry),
+        LauntelEstimatedDaysRemainingSensor(coordinator, entry),
     ]
     async_add_entities(entities)
 
@@ -119,6 +120,50 @@ class LauntelBalanceSensor(CoordinatorEntity, SensorEntity):
             attrs.update({
                 "balance_status": "credit" if balance >= 0 else "debt",
                 "formatted_balance": f"${abs(balance):.2f}",
+            })
+        
+        return attrs
+
+
+class LauntelEstimatedDaysRemainingSensor(CoordinatorEntity, SensorEntity):
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:calendar-clock"
+    _attr_native_unit_of_measurement = "days"
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        svc = coordinator.data.get("service")
+        title = svc.title if svc else entry.title
+        self._attr_name = f"{title} estimated days remaining"
+        self._attr_unique_id = f"{entry.data['service_id']}_estimated_days_remaining"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        svc = self.coordinator.data.get("service")
+        name = svc.title if svc else self._entry.title
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self._entry.data["service_id"]))},
+            name=name,
+            manufacturer="Launtel",
+            model="Internet Service",
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        return self.coordinator.data.get("estimated_days_remaining")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        days_remaining = self.coordinator.data.get("estimated_days_remaining")
+        attrs: dict[str, Any] = {
+            "last_updated": self.coordinator.last_update_success,
+        }
+        
+        if days_remaining is not None:
+            attrs.update({
+                "status": "low" if days_remaining < 7 else "normal",
+                "weeks_remaining": round(days_remaining / 7, 1),
             })
         
         return attrs


### PR DESCRIPTION
Added support for monitoring and displaying the Launtel account balance in Home Assistant, as well as introducing a refresh button entity. The main changes include the implementation of balance scraping method, parallel fetching of services and balance, and the addition of new sensor and button entities to expose this functionality in the UI.

**Account Balance Support:**

* Added an `async_get_balance` method to `LauntelApi` that scrapes the Launtel portal for the current account balance using multiple fallback strategies for robustness.
* Updated the main update routine in `__init__.py` to fetch services and balance in parallel using `asyncio.gather`, handle exceptions gracefully, and store the account balance in the coordinator data.
* The account balance is now included in the coordinator data dictionary as `account_balance`.

**New Entities:**

* Introduced a new `LauntelBalanceSensor` entity to display the account balance in Home Assistant, including device class and currency unit, and exposing additional attributes such as balance status and formatted balance. [[1]](diffhunk://#diff-8faef98244450fc51b86825366aa2394a6993d8d562a80c953ce2be1c4429ffeL19-R24) [[2]](diffhunk://#diff-8faef98244450fc51b86825366aa2394a6993d8d562a80c953ce2be1c4429ffeR80-R124) [[3]](diffhunk://#diff-8faef98244450fc51b86825366aa2394a6993d8d562a80c953ce2be1c4429ffeL5-R11)
* Added a `LauntelRefreshButton` entity to allow users to manually trigger a data refresh from the Home Assistant UI.
* Registered the new `button` platform in the integration's supported platforms.
