### PR TITLE
Add pytest coverage for Launtel integration

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 typer
 aiohttp
 beautifulsoup4
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,48 +2,58 @@
 #    uv pip compile requirements.in --output-file requirements.txt
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.15
+aiohttp==3.13.0
     # via -r requirements.in
 aiosignal==1.4.0
     # via aiohttp
-attrs==25.3.0
+attrs==25.4.0
     # via aiohttp
-beautifulsoup4==4.13.5
+beautifulsoup4==4.14.2
     # via -r requirements.in
-click==8.2.1
+click==8.3.0
     # via typer
-frozenlist==1.7.0
+frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.10
+idna==3.11
     # via yarl
+iniconfig==2.1.0
+    # via pytest
 markdown-it-py==4.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.6.4
+multidict==6.7.0
     # via
     #   aiohttp
     #   yarl
-propcache==0.3.2
+packaging==25.0
+    # via pytest
+pluggy==1.6.0
+    # via pytest
+propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
 pygments==2.19.2
-    # via rich
-rich==14.1.0
+    # via
+    #   pytest
+    #   rich
+pytest==8.4.2
+    # via -r requirements.in
+rich==14.2.0
     # via typer
 shellingham==1.5.4
     # via typer
 soupsieve==2.8
     # via beautifulsoup4
-typer==0.16.1
+typer==0.19.2
     # via -r requirements.in
 typing-extensions==4.15.0
     # via
     #   aiosignal
     #   beautifulsoup4
     #   typer
-yarl==1.20.1
+yarl==1.22.0
     # via aiohttp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,193 @@
+import asyncio
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    sys.modules[name] = module
+    return module
+
+
+# Create base package modules
+ha = _ensure_module("homeassistant")
+ha.helpers = types.ModuleType("homeassistant.helpers")
+ha.components = types.ModuleType("homeassistant.components")
+ha.core = types.ModuleType("homeassistant.core")
+ha.config_entries = types.ModuleType("homeassistant.config_entries")
+ha.data_entry_flow = types.ModuleType("homeassistant.data_entry_flow")
+ha.exceptions = types.ModuleType("homeassistant.exceptions")
+ha.const = types.ModuleType("homeassistant.const")
+ha.helpers.aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+ha.helpers.update_coordinator = types.ModuleType("homeassistant.helpers.update_coordinator")
+ha.helpers.entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+ha.helpers.device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+ha.components.sensor = types.ModuleType("homeassistant.components.sensor")
+ha.components.select = types.ModuleType("homeassistant.components.select")
+ha.components.button = types.ModuleType("homeassistant.components.button")
+
+vol = types.ModuleType("voluptuous")
+
+
+class _Schema:
+    def __init__(self, schema):
+        self.schema = schema
+
+    def __call__(self, data):  # pragma: no cover - not used in tests
+        return data
+
+
+vol.Schema = _Schema
+vol.Required = lambda key: key
+vol.In = lambda options: options
+
+sys.modules["voluptuous"] = vol
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+sys.modules["homeassistant.helpers"] = ha.helpers
+sys.modules["homeassistant.components"] = ha.components
+sys.modules["homeassistant.core"] = ha.core
+sys.modules["homeassistant.config_entries"] = ha.config_entries
+sys.modules["homeassistant.data_entry_flow"] = ha.data_entry_flow
+sys.modules["homeassistant.exceptions"] = ha.exceptions
+sys.modules["homeassistant.const"] = ha.const
+sys.modules["homeassistant.helpers.aiohttp_client"] = ha.helpers.aiohttp_client
+sys.modules["homeassistant.helpers.update_coordinator"] = ha.helpers.update_coordinator
+sys.modules["homeassistant.helpers.entity_platform"] = ha.helpers.entity_platform
+sys.modules["homeassistant.helpers.device_registry"] = ha.helpers.device_registry
+sys.modules["homeassistant.components.sensor"] = ha.components.sensor
+sys.modules["homeassistant.components.select"] = ha.components.select
+sys.modules["homeassistant.components.button"] = ha.components.button
+
+
+class HomeAssistant:
+    def __init__(self):
+        self.data: dict[str, Any] = {}
+        self.config_entries = types.SimpleNamespace(
+            async_forward_entry_setups=lambda entry, platforms: None,
+            async_unload_platforms=lambda entry, platforms: True,
+        )
+
+
+ha.core.HomeAssistant = HomeAssistant
+
+
+class ConfigFlow:
+    def __init_subclass__(cls, *, domain: str | None = None, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._domain = domain
+
+    def async_show_form(self, *, step_id: str, data_schema=None, errors=None):
+        return {"type": "form", "step_id": step_id, "data_schema": data_schema, "errors": errors or {}}
+
+    def async_abort(self, *, reason: str):
+        return {"type": "abort", "reason": reason}
+
+    def async_create_entry(self, *, title: str, data: dict[str, Any]):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    async def async_set_unique_id(self, unique_id: str):
+        self._unique_id = unique_id
+
+    def _abort_if_unique_id_configured(self):
+        return None
+
+
+ha.config_entries.ConfigFlow = ConfigFlow
+ha.config_entries.ConfigEntry = object
+ha.data_entry_flow.FlowResult = dict
+
+
+class CoordinatorEntity:
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+
+class DataUpdateCoordinator:
+    def __init__(self, hass, logger, name, update_method, update_interval):
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_method = update_method
+        self.update_interval = update_interval
+        self.data = {}
+        self.last_update_success = True
+
+    async def async_config_entry_first_refresh(self):
+        self.data = await self.update_method()
+
+    async def async_request_refresh(self):
+        self.data = await self.update_method()
+
+    def async_set_updated_data(self, data):
+        self.data = data
+
+
+ha.helpers.update_coordinator.CoordinatorEntity = CoordinatorEntity
+ha.helpers.update_coordinator.DataUpdateCoordinator = DataUpdateCoordinator
+
+
+ha.helpers.aiohttp_client.async_get_clientsession = lambda hass: object()
+
+AddEntitiesCallback = Callable[[list], None]
+ha.helpers.entity_platform.AddEntitiesCallback = AddEntitiesCallback
+
+
+@dataclass
+class DeviceInfo:
+    identifiers: set[tuple[str, str]]
+    name: str
+    manufacturer: str
+    model: str
+
+
+ha.helpers.device_registry.DeviceInfo = DeviceInfo
+
+
+class SensorEntity:
+    pass
+
+
+ha.components.sensor.SensorEntity = SensorEntity
+ha.components.sensor.SensorDeviceClass = types.SimpleNamespace(MONETARY="monetary")
+
+
+class SelectEntity:
+    pass
+
+
+ha.components.select.SelectEntity = SelectEntity
+
+
+class ButtonEntity:
+    pass
+
+
+ha.components.button.ButtonEntity = ButtonEntity
+
+
+class HomeAssistantError(Exception):
+    pass
+
+
+ha.exceptions.HomeAssistantError = HomeAssistantError
+
+ha.const.CURRENCY_DOLLAR = "$"
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "asyncio: run test in asyncio event loop")
+
+
+def pytest_pyfunc_call(pyfuncitem):
+    if "asyncio" in pyfuncitem.keywords:
+        coro = pyfuncitem.obj(**pyfuncitem.funcargs)
+        asyncio.run(coro)
+        return True
+    return None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,155 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.launtel.api import LauntelClient, LauntelService
+
+
+class DummyResponse:
+    def __init__(self, *, status: int = 200, text: str = "", raise_for_status: bool = False):
+        self.status = status
+        self._text = text
+        self.raise_for_status = Mock()
+        if raise_for_status:
+            self.raise_for_status.side_effect = RuntimeError("boom")
+
+    async def text(self):
+        return self._text
+
+
+@pytest.mark.asyncio
+async def test_async_login_success(monkeypatch):
+    session = AsyncMock()
+    resp = DummyResponse(status=200, text="logged in")
+    session.post.return_value = resp
+    client = LauntelClient(session, "user", "pass")
+
+    await client.async_login()
+
+    session.post.assert_awaited_once()
+    assert client._logged_in
+
+
+@pytest.mark.asyncio
+async def test_async_login_failure(monkeypatch):
+    session = AsyncMock()
+    resp = DummyResponse(status=200, text='<input name="username">')
+    session.post.return_value = resp
+    client = LauntelClient(session, "user", "pass")
+
+    with pytest.raises(RuntimeError):
+        await client.async_login()
+
+    session.post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_get_services_parses_cards(monkeypatch):
+    session = AsyncMock()
+    services_html = """
+    <div class="service-card" id="svc-123">
+      <span class="service-title-txt">My Fibre</span>
+      <a href="/charts?foo=1&userid=abc123"><i class="fa-bar-chart"></i></a>
+      <button onclick="pauseService(456)"></button>
+      <dt>Technology / Speed Tier</dt>
+      <dd>Fibre 250 / 100 Mbps</dd>
+      <dt>Status</dt>
+      <dd><span>Change in progress</span></dd>
+    </div>
+    """
+    session.get.return_value = DummyResponse(text=services_html)
+
+    client = LauntelClient(session, "user", "pass")
+    client._logged_in = True
+
+    services = await client.async_get_services()
+
+    assert services == [
+        LauntelService(
+            title="My Fibre",
+            service_id=456,
+            avcid="svc-123",
+            user_id="abc123",
+            speed_label="Fibre 250 / 100 Mbps",
+            change_in_progress=True,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_get_plan_options(monkeypatch):
+    session = AsyncMock()
+    html = """
+    <input name="psid" value="1001">
+    <span class="list-group-item" data-value="1001" data-plancharge="2.5">
+      <div class="row"><div class="col-8">Fibre (250/100) Unlimited</div></div>
+    </span>
+    <span class="list-group-item" data-value="1002" data-plancharge="1.5">Basic 25/5</span>
+    <input name="locid" value="loc-55">
+    """
+    session.get.return_value = DummyResponse(text=html)
+
+    client = LauntelClient(session, "user", "pass")
+    client._logged_in = True
+
+    options, label_to_psid, current_label, locid, plans_mapping = await client.async_get_plan_options("svc-123")
+
+    assert options == ["Fibre (250/100) Unlimited", "Basic 25/5"]
+    assert label_to_psid["Fibre (250/100) Unlimited"] == 1001
+    assert current_label == "Fibre (250/100) Unlimited"
+    assert locid == "loc-55"
+    assert plans_mapping[1001]["price_per_day"] == 2.5
+    assert plans_mapping[1001]["unlimited"] is True
+    assert plans_mapping[1001]["speed"] == "250/100"
+
+
+@pytest.mark.asyncio
+async def test_async_change_plan(monkeypatch):
+    session = AsyncMock()
+    get_resp = DummyResponse(text="ok")
+    post_resp = DummyResponse(text="done")
+    session.get.return_value = get_resp
+    session.post.return_value = post_resp
+
+    client = LauntelClient(session, "user", "pass")
+    client._logged_in = True
+
+    await client.async_change_plan("uid", 10, 5, "avc", "loc")
+
+    session.get.assert_awaited()
+    session.post.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_get_balance(monkeypatch):
+    session = AsyncMock()
+    html = """
+    <dt>Current Balance</dt>
+    <dd><span>+$112.65</span></dd>
+    """
+    session.get.return_value = DummyResponse(text=html)
+
+    client = LauntelClient(session, "user", "pass")
+    client._logged_in = True
+
+    balance = await client.async_get_balance()
+
+    assert balance == 112.65
+
+
+@pytest.mark.asyncio
+async def test_async_get_estimated_days_remaining(monkeypatch):
+    session = AsyncMock()
+    html = """
+    <dt>Estimated Days Remaining</dt>
+    <dd><span class="text-success">27</span></dd>
+    """
+    session.get.return_value = DummyResponse(text=html)
+
+    client = LauntelClient(session, "user", "pass")
+    client._logged_in = True
+
+    days = await client.async_get_estimated_days_remaining()
+
+    assert days == 27

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,25 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from custom_components.launtel.button import LauntelRefreshButton
+
+
+class DummyCoordinator(SimpleNamespace):
+    async def async_request_refresh(self):
+        self.called = True
+
+
+def _make_entry():
+    return SimpleNamespace(data={"service_id": 99}, title="Service")
+
+
+@pytest.mark.asyncio
+async def test_refresh_button_triggers_refresh():
+    coordinator = DummyCoordinator(data={"service": SimpleNamespace(title="Service")})
+    coordinator.called = False
+    button = LauntelRefreshButton(coordinator, _make_entry())
+
+    await button.async_press()
+
+    assert coordinator.called is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,112 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from typer.testing import CliRunner
+
+from custom_components.launtel import api
+from launtel_cli import app
+
+
+runner = CliRunner()
+
+
+class DummySession:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class DummyClient(SimpleNamespace):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def patch_run(monkeypatch):
+    def _run(coro):
+        return asyncio.run(coro)
+
+    monkeypatch.setattr("launtel_cli._run", _run)
+
+
+def test_services_command(monkeypatch):
+    client = DummyClient()
+    client.async_get_services = AsyncMock(return_value=[
+        api.LauntelService(title="Svc", service_id=1, avcid="avc", user_id="user", speed_label="Speed", change_in_progress=False)
+    ])
+    session = DummySession()
+
+    async def _get_client(username, password):
+        return client, session
+
+    monkeypatch.setattr("launtel_cli._get_client", _get_client)
+
+    result = runner.invoke(app, ["services", "--username", "user", "--password", "pass"])
+
+    assert result.exit_code == 0
+    assert "service_id=1" in result.stdout
+    assert session.closed is True
+
+
+def test_plans_command(monkeypatch):
+    client = DummyClient()
+    client.async_get_services = AsyncMock(return_value=[
+        api.LauntelService(title="Svc", service_id=1, avcid="avc", user_id="user", speed_label="Speed", change_in_progress=False)
+    ])
+    client.async_get_plan_options = AsyncMock(return_value=(
+        ["Plan"], {"Plan": 10}, "Plan", "loc", {10: {"price_per_day": 2.5, "speed": "250/100", "unlimited": True}}
+    ))
+    session = DummySession()
+
+    async def _get_client(username, password):
+        return client, session
+
+    monkeypatch.setattr("launtel_cli._get_client", _get_client)
+
+    result = runner.invoke(app, [
+        "plans",
+        "--username",
+        "user",
+        "--password",
+        "pass",
+        "--service-id",
+        "1",
+    ])
+
+    assert result.exit_code == 0
+    assert "Current plan: Plan" in result.stdout
+
+
+def test_change_plan_command(monkeypatch):
+    client = DummyClient()
+    client.async_get_services = AsyncMock(return_value=[
+        api.LauntelService(title="Svc", service_id=1, avcid="avc", user_id="user", speed_label="Speed", change_in_progress=False)
+    ])
+    client.async_get_plan_options = AsyncMock(return_value=(
+        ["Plan"], {"Plan": 10}, "Plan", "loc", {}
+    ))
+    client.async_change_plan = AsyncMock()
+    session = DummySession()
+
+    async def _get_client(username, password):
+        return client, session
+
+    monkeypatch.setattr("launtel_cli._get_client", _get_client)
+
+    result = runner.invoke(app, [
+        "change-plan",
+        "--username",
+        "user",
+        "--password",
+        "pass",
+        "--service-id",
+        "1",
+        "--label",
+        "Plan",
+    ])
+
+    assert result.exit_code == 0
+    client.async_change_plan.assert_awaited()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.launtel import config_flow
+from custom_components.launtel.api import LauntelService
+
+
+class DummyHass(SimpleNamespace):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_user_step_success(monkeypatch):
+    hass = DummyHass()
+    session = object()
+    fake_client = SimpleNamespace()
+    fake_client.async_login = AsyncMock()
+    fake_client.async_get_services = AsyncMock(return_value=[
+        LauntelService(title="Svc", service_id=1, avcid="avc", user_id="user", speed_label="Speed", change_in_progress=False)
+    ])
+
+    monkeypatch.setattr(config_flow, "async_get_clientsession", lambda hass: session)
+    monkeypatch.setattr(config_flow, "LauntelClient", lambda *args, **kwargs: fake_client)
+
+    flow = config_flow.LauntelConfigFlow()
+    flow.hass = hass
+
+    result = await flow.async_step_user({"username": "user", "password": "pass"})
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "select_service"
+    assert flow._services
+
+
+@pytest.mark.asyncio
+async def test_user_step_no_services(monkeypatch):
+    hass = DummyHass()
+    fake_client = SimpleNamespace()
+    fake_client.async_login = AsyncMock()
+    fake_client.async_get_services = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(config_flow, "async_get_clientsession", lambda hass: object())
+    monkeypatch.setattr(config_flow, "LauntelClient", lambda *args, **kwargs: fake_client)
+
+    flow = config_flow.LauntelConfigFlow()
+    flow.hass = hass
+
+    result = await flow.async_step_user({"username": "user", "password": "pass"})
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "no_services"
+
+
+@pytest.mark.asyncio
+async def test_select_service_creates_entry(monkeypatch):
+    flow = config_flow.LauntelConfigFlow()
+    flow.hass = DummyHass()
+    flow._username = "user"
+    flow._password = "pass"
+    flow._services = [
+        LauntelService(title="Svc", service_id=1, avcid="avc", user_id="user", speed_label="Speed", change_in_progress=False)
+    ]
+
+    result = await flow.async_step_select_service({"service_id": 1})
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Svc"
+    assert result["data"]["service_id"] == 1

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,10 @@
+from custom_components.launtel import const
+
+
+def test_constants_values():
+    assert const.DOMAIN == "launtel"
+    assert const.DEFAULT_NAME == "Launtel"
+    assert const.CONF_USERNAME == "username"
+    assert const.CONF_PASSWORD == "password"
+    assert const.CONF_SERVICE_ID == "service_id"
+    assert const.PLATFORMS == ["button", "select", "sensor"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.launtel.api import LauntelService
+
+launtel_init = import_module("custom_components.launtel.__init__")
+
+
+class DummyCoordinator:
+    def __init__(self, hass, logger, name, update_method, update_interval):
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_method = update_method
+        self.update_interval = update_interval
+        self.data = {}
+        self.last_update_success = True
+
+    async def async_config_entry_first_refresh(self):
+        self.data = await self.update_method()
+
+    async def async_request_refresh(self):
+        await self.update_method()
+
+    def async_set_updated_data(self, data):
+        self.data = data
+
+
+class FakeConfigEntries:
+    def __init__(self):
+        self.forwarded = []
+        self.unloaded = []
+
+    async def async_forward_entry_setups(self, entry, platforms):
+        self.forwarded.append((entry, tuple(platforms)))
+
+    async def async_unload_platforms(self, entry, platforms):
+        self.unloaded.append((entry, tuple(platforms)))
+        return True
+
+
+class FakeEntry:
+    def __init__(self):
+        self.entry_id = "entry1"
+        self.title = "My Service"
+        self.data = {
+            "username": "user",
+            "password": "pass",
+            "service_id": 123,
+            "avcid": "avc1",
+            "user_id": "user123",
+        }
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry(monkeypatch):
+    hass = SimpleNamespace()
+    hass.data = {}
+    hass.config_entries = FakeConfigEntries()
+
+    fake_client = MagicMock()
+    fake_client.async_get_services = AsyncMock(return_value=[
+        LauntelService(title="My Service", service_id=123, avcid="avc1", user_id="user123", speed_label="Speed", change_in_progress=False)
+    ])
+    fake_client.async_get_balance = AsyncMock(return_value=50.5)
+    fake_client.async_get_estimated_days_remaining = AsyncMock(return_value=10)
+    fake_client.async_get_plan_options = AsyncMock(return_value=(
+        ["Option A"], {"Option A": 99}, "Option A", "loc", {99: {"label": "Option A", "price_per_day": 2.5, "unlimited": True, "speed": "250/100", "first_col": "col"}}
+    ))
+
+    session = object()
+
+    monkeypatch.setattr(launtel_init, "async_get_clientsession", lambda hass: session)
+    monkeypatch.setattr(launtel_init, "LauntelClient", lambda *args, **kwargs: fake_client)
+    monkeypatch.setattr(launtel_init, "DataUpdateCoordinator", DummyCoordinator)
+
+    entry = FakeEntry()
+
+    result = await launtel_init.async_setup_entry(hass, entry)
+
+    assert result is True
+    assert hass.data[launtel_init.DOMAIN][entry.entry_id]["client"] is fake_client
+    coordinator = hass.data[launtel_init.DOMAIN][entry.entry_id]["coordinator"]
+    assert coordinator.data["current_label"] == "Option A"
+    assert hass.config_entries.forwarded[0][1] == tuple(launtel_init.PLATFORMS)
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry():
+    hass = SimpleNamespace()
+    hass.data = {launtel_init.DOMAIN: {"entry1": {}}}
+    hass.config_entries = FakeConfigEntries()
+    entry = FakeEntry()
+
+    result = await launtel_init.async_unload_entry(hass, entry)
+
+    assert result is True
+    assert entry.entry_id not in hass.data.get(launtel_init.DOMAIN, {})
+    assert hass.config_entries.unloaded[0][1] == tuple(launtel_init.PLATFORMS)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,95 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.launtel.select import LauntelPlanSelect
+
+
+class DummyCoordinator(SimpleNamespace):
+    def __init__(self, data):
+        super().__init__(data=data)
+
+    async def async_request_refresh(self):
+        self.data.setdefault("refresh_called", 0)
+        self.data["refresh_called"] += 1
+
+    def async_set_updated_data(self, data):
+        self.data = data
+
+
+def _make_entry():
+    return SimpleNamespace(data={"service_id": 1}, title="Service")
+
+
+def _make_client():
+    client = SimpleNamespace()
+    client.async_change_plan = AsyncMock()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_select_option_success():
+    coordinator = DummyCoordinator(
+        {
+            "service": SimpleNamespace(title="Service"),
+            "change_in_progress": False,
+            "options": ["Plan A"],
+            "label_to_psid": {"Plan A": 10},
+            "user_id": "uid",
+            "service_id": 5,
+            "avcid": "avc",
+            "locid": "loc",
+        }
+    )
+    select = LauntelPlanSelect(coordinator, _make_client(), _make_entry())
+
+    await select.async_select_option("Plan A")
+
+    assert select.coordinator.data["change_in_progress"] is True
+    select._client.async_change_plan.assert_awaited_once_with("uid", 10, 5, "avc", "loc")
+
+
+@pytest.mark.asyncio
+async def test_select_option_requires_availability():
+    coordinator = DummyCoordinator(
+        {
+            "service": SimpleNamespace(title="Service"),
+            "change_in_progress": True,
+        }
+    )
+    select = LauntelPlanSelect(coordinator, _make_client(), _make_entry())
+
+    with pytest.raises(HomeAssistantError):
+        await select.async_select_option("Plan A")
+
+
+@pytest.mark.asyncio
+async def test_select_option_fetches_locid():
+    coordinator = DummyCoordinator(
+        {
+            "service": SimpleNamespace(title="Service"),
+            "change_in_progress": False,
+            "options": ["Plan A"],
+            "label_to_psid": {"Plan A": 10},
+            "user_id": "uid",
+            "service_id": 5,
+            "avcid": "avc",
+            "locid": None,
+        }
+    )
+    client = _make_client()
+    select = LauntelPlanSelect(coordinator, client, _make_entry())
+
+    async def _refresh():
+        coordinator.data.setdefault("refresh_called", 0)
+        coordinator.data["refresh_called"] += 1
+        coordinator.data["locid"] = "loc"
+
+    coordinator.async_request_refresh = AsyncMock(side_effect=_refresh)
+
+    await select.async_select_option("Plan A")
+
+    client.async_change_plan.assert_awaited_once_with("uid", 10, 5, "avc", "loc")
+    assert coordinator.async_request_refresh.await_count >= 1

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+from custom_components.launtel.sensor import (
+    LauntelBalanceSensor,
+    LauntelCurrentPlanSensor,
+    LauntelEstimatedDaysRemainingSensor,
+)
+
+
+class DummyCoordinator(SimpleNamespace):
+    def __init__(self, data):
+        super().__init__(data=data, last_update_success=True)
+
+
+class DummyEntry(SimpleNamespace):
+    pass
+
+
+def _make_entry():
+    return DummyEntry(data={"service_id": 123}, title="Service Title")
+
+
+def test_current_plan_sensor_properties():
+    coordinator = DummyCoordinator(
+        {
+            "service": SimpleNamespace(title="Service Title"),
+            "change_in_progress": False,
+            "current_label": "Plan A",
+            "label_to_psid": {"Plan A": 1},
+            "plans_mapping": {1: {"label": "Plan A", "price_per_day": 2.5, "unlimited": True, "speed": "250/100"}},
+            "options": ["Plan A"],
+            "service_speed_label": "Speed",
+        }
+    )
+    entry = _make_entry()
+    sensor = LauntelCurrentPlanSensor(coordinator, entry)
+
+    assert sensor.native_value == "Plan A"
+    attrs = sensor.extra_state_attributes
+    assert attrs["current_price_per_day"] == 2.5
+    assert attrs["plans"]["1"]["label"] == "Plan A"
+
+    coordinator.data["change_in_progress"] = True
+    assert sensor.native_value == "Change in progress"
+
+
+def test_balance_sensor_attributes():
+    coordinator = DummyCoordinator(
+        {
+            "service": SimpleNamespace(title="Service Title"),
+            "account_balance": -12.34,
+        }
+    )
+    entry = _make_entry()
+    sensor = LauntelBalanceSensor(coordinator, entry)
+
+    assert sensor.native_value == -12.34
+    attrs = sensor.extra_state_attributes
+    assert attrs["balance_status"] == "debt"
+    assert attrs["formatted_balance"] == "$12.34"
+
+
+def test_days_remaining_sensor_attributes():
+    coordinator = DummyCoordinator(
+        {
+            "service": SimpleNamespace(title="Service Title"),
+            "estimated_days_remaining": 5,
+        }
+    )
+    entry = _make_entry()
+    sensor = LauntelEstimatedDaysRemainingSensor(coordinator, entry)
+
+    assert sensor.native_value == 5
+    attrs = sensor.extra_state_attributes
+    assert attrs["status"] == "low"
+    assert attrs["weeks_remaining"] == 0.7


### PR DESCRIPTION
## Summary
- add a lightweight Home Assistant and voluptuous test harness so the integration can be tested in isolation
- cover the Launtel API client, config flow, coordinator setup, entities, constants, and CLI with pytest unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f073350998832b9d036c80f62f8722