### PR TITLE
Allow selecting plans by speed string

### DIFF
--- a/custom_components/launtel/select.py
+++ b/custom_components/launtel/select.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Optional
 
 from homeassistant.components.select import SelectEntity
@@ -64,6 +65,9 @@ class LauntelPlanSelect(CoordinatorEntity, SelectEntity):
         mapping = self.coordinator.data.get("label_to_psid", {})
         psid = mapping.get(option)
         if psid is None:
+            psid = self._find_psid_from_speed(option)
+        if psid is None:
+            await self.coordinator.async_request_refresh()
             raise HomeAssistantError("Invalid plan option selected")
         user_id: str = self.coordinator.data.get("user_id")
         service_id: int = self.coordinator.data.get("service_id")
@@ -86,3 +90,18 @@ class LauntelPlanSelect(CoordinatorEntity, SelectEntity):
         # This method is synchronous (despite the name) in HA
         self.coordinator.async_set_updated_data(data)
         await self.coordinator.async_request_refresh()
+
+    def _find_psid_from_speed(self, option: str) -> Optional[int]:
+        """Try to resolve a plan PSID from a speed string like "100/20"."""
+
+        match = re.fullmatch(r"\s*(\d+)\s*/\s*(\d+)\s*", option)
+        if not match:
+            return None
+
+        speed = f"{match.group(1)}/{match.group(2)}"
+        plans_mapping = self.coordinator.data.get("plans_mapping", {})
+        for psid, plan in plans_mapping.items():
+            plan_speed = plan.get("speed") if isinstance(plan, dict) else None
+            if plan_speed and plan_speed.replace(" ", "") == speed:
+                return psid
+        return None

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -93,3 +93,52 @@ async def test_select_option_fetches_locid():
 
     client.async_change_plan.assert_awaited_once_with("uid", 10, 5, "avc", "loc")
     assert coordinator.async_request_refresh.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_select_option_by_speed():
+    coordinator = DummyCoordinator(
+        {
+            "service": SimpleNamespace(title="Service"),
+            "change_in_progress": False,
+            "options": ["Plan A", "Plan B"],
+            "label_to_psid": {"Plan A": 10, "Plan B": 11},
+            "user_id": "uid",
+            "service_id": 5,
+            "avcid": "avc",
+            "locid": "loc",
+            "plans_mapping": {
+                10: {"speed": "100/20"},
+                11: {"speed": "50/20"},
+            },
+        }
+    )
+    select = LauntelPlanSelect(coordinator, _make_client(), _make_entry())
+
+    await select.async_select_option("100 / 20")
+
+    select._client.async_change_plan.assert_awaited_once_with("uid", 10, 5, "avc", "loc")
+
+
+@pytest.mark.asyncio
+async def test_select_option_by_speed_invalid():
+    coordinator = DummyCoordinator(
+        {
+            "service": SimpleNamespace(title="Service"),
+            "change_in_progress": False,
+            "options": ["Plan A"],
+            "label_to_psid": {"Plan A": 10},
+            "user_id": "uid",
+            "service_id": 5,
+            "avcid": "avc",
+            "locid": "loc",
+            "plans_mapping": {10: {"speed": "100/20"}},
+        }
+    )
+    select = LauntelPlanSelect(coordinator, _make_client(), _make_entry())
+
+    with pytest.raises(HomeAssistantError):
+        await select.async_select_option("999/1")
+
+    assert coordinator.data.get("refresh_called") == 1
+    select._client.async_change_plan.assert_not_awaited()


### PR DESCRIPTION
## Summary
- allow the Launtel plan select entity to resolve plan IDs from speed-only strings
- refresh the coordinator and raise an error when no matching plan is found
- add tests covering speed-based selection and rollback behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f07cb5ab60832ba9d156ce23d7ba70