### PR TITLE
Add HomeKit-compatible metadata to Launtel sensors

### DIFF
--- a/custom_components/launtel/sensor.py
+++ b/custom_components/launtel/sensor.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.const import CURRENCY_DOLLAR
+from homeassistant.const import CURRENCY_DOLLAR, UnitOfTime
 
 from .const import DOMAIN
 
@@ -85,6 +85,7 @@ class LauntelBalanceSensor(CoordinatorEntity, SensorEntity):
     _attr_icon = "mdi:currency-usd"
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_native_unit_of_measurement = CURRENCY_DOLLAR
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)
@@ -128,7 +129,9 @@ class LauntelBalanceSensor(CoordinatorEntity, SensorEntity):
 class LauntelEstimatedDaysRemainingSensor(CoordinatorEntity, SensorEntity):
     _attr_has_entity_name = True
     _attr_icon = "mdi:calendar-clock"
-    _attr_native_unit_of_measurement = "days"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.DAYS
+    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,11 +151,31 @@ ha.helpers.device_registry.DeviceInfo = DeviceInfo
 
 
 class SensorEntity:
-    pass
+    _attr_device_class = None
+    _attr_native_unit_of_measurement = None
+    _attr_state_class = None
+
+    @property
+    def device_class(self):
+        return getattr(self, "_attr_device_class", None)
+
+    @property
+    def native_unit_of_measurement(self):
+        return getattr(self, "_attr_native_unit_of_measurement", None)
+
+    @property
+    def state_class(self):
+        return getattr(self, "_attr_state_class", None)
 
 
 ha.components.sensor.SensorEntity = SensorEntity
-ha.components.sensor.SensorDeviceClass = types.SimpleNamespace(MONETARY="monetary")
+ha.components.sensor.SensorDeviceClass = types.SimpleNamespace(
+    MONETARY="monetary",
+    DURATION="duration",
+)
+ha.components.sensor.SensorStateClass = types.SimpleNamespace(
+    MEASUREMENT="measurement",
+)
 
 
 class SelectEntity:
@@ -179,6 +199,7 @@ class HomeAssistantError(Exception):
 ha.exceptions.HomeAssistantError = HomeAssistantError
 
 ha.const.CURRENCY_DOLLAR = "$"
+ha.const.UnitOfTime = types.SimpleNamespace(DAYS="days")
 
 
 def pytest_configure(config):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,8 @@ from custom_components.launtel.sensor import (
     LauntelCurrentPlanSensor,
     LauntelEstimatedDaysRemainingSensor,
 )
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import CURRENCY_DOLLAR, UnitOfTime
 
 
 class DummyCoordinator(SimpleNamespace):
@@ -55,6 +57,9 @@ def test_balance_sensor_attributes():
     sensor = LauntelBalanceSensor(coordinator, entry)
 
     assert sensor.native_value == -12.34
+    assert sensor.device_class is SensorDeviceClass.MONETARY
+    assert sensor.native_unit_of_measurement == CURRENCY_DOLLAR
+    assert sensor.state_class is SensorStateClass.MEASUREMENT
     attrs = sensor.extra_state_attributes
     assert attrs["balance_status"] == "debt"
     assert attrs["formatted_balance"] == "$12.34"
@@ -71,6 +76,9 @@ def test_days_remaining_sensor_attributes():
     sensor = LauntelEstimatedDaysRemainingSensor(coordinator, entry)
 
     assert sensor.native_value == 5
+    assert sensor.device_class is SensorDeviceClass.DURATION
+    assert sensor.native_unit_of_measurement == UnitOfTime.DAYS
+    assert sensor.state_class is SensorStateClass.MEASUREMENT
     attrs = sensor.extra_state_attributes
     assert attrs["status"] == "low"
     assert attrs["weeks_remaining"] == 0.7


### PR DESCRIPTION
## Summary
- add measurement state class metadata to the Launtel balance and days remaining sensors for HomeKit compatibility
- expose the estimated days remaining sensor as a duration in days for clearer HomeKit presentation
- extend the Home Assistant test stubs to cover the added sensor metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69051685a268832babd46fdcd96c8949