### PR TITLE
Feature - Add Usage Data (GB)

### DIFF
--- a/custom_components/launtel/__init__.py
+++ b/custom_components/launtel/__init__.py
@@ -9,7 +9,8 @@ from aiohttp import ClientSession
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, PLATFORMS
 from .api import LauntelClient, LauntelService
@@ -28,6 +29,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Polling intervals
     NORMAL_INTERVAL = timedelta(hours=6)
     CHANGE_POLL_INTERVAL = timedelta(minutes=1)
+    # Usage data updates stepwise through the day (not live), so a tighter but
+    # still gentle cadence captures changes without hammering the portal.
+    USAGE_INTERVAL = timedelta(minutes=30)
 
     # Keep last known service to handle transient portal states
     previous_service: Optional[LauntelService] = None
@@ -51,26 +55,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             services_task = client.async_get_services()
             balance_task = client.async_get_balance()
             days_task = client.async_get_estimated_days_remaining()
-            
+
             services, balance, estimated_days_remaining = await asyncio.gather(
                 services_task, balance_task, days_task, return_exceptions=True
             )
-            
+
             # Handle services result
             if isinstance(services, Exception):
                 _LOGGER.debug("Services fetch error: %s", services)
                 services = []
-            
+
             # Handle balance result
             if isinstance(balance, Exception):
                 _LOGGER.debug("Balance fetch error: %s", balance)
                 balance = None
-            
+
             # Handle estimated days remaining result
             if isinstance(estimated_days_remaining, Exception):
                 _LOGGER.debug("Estimated days remaining fetch error: %s", estimated_days_remaining)
                 estimated_days_remaining = None
-            
+
             svc = next((s for s in services if s.service_id == service_id), None)
 
             if not svc:
@@ -171,9 +175,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
+    # ------------------------------------------------------------------
+    # Dedicated usage coordinator.
+    # Kept separate from the plan/balance coordinator so daily-usage polling
+    # runs on its own gentle cadence and isn't coupled to the 6h/1min plan
+    # scrape. The /usage page is keyed on user_id, which is already stored in
+    # the config entry, so no extra configuration is required.
+    # ------------------------------------------------------------------
+    async def _async_update_usage() -> dict[str, Any]:
+        try:
+            usage = await client.async_get_usage(user_id, day=dt_util.now().day)
+        except Exception as err:  # noqa: BLE001
+            raise UpdateFailed(f"Launtel usage fetch failed: {err}") from err
+        if usage is None:
+            raise UpdateFailed("Could not parse Launtel usage page")
+        return usage
+
+    usage_coordinator = DataUpdateCoordinator(
+        hass,
+        logger=_LOGGER,
+        name=f"Launtel usage {service_id}",
+        update_method=_async_update_usage,
+        update_interval=USAGE_INTERVAL,
+    )
+
+    # Use async_refresh (not async_config_entry_first_refresh) so a failed first
+    # usage scrape does NOT abort setup of the whole integration. The usage
+    # sensors will simply start unavailable and recover on the next poll.
+    await usage_coordinator.async_refresh()
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "client": client,
         "coordinator": coordinator,
+        "usage_coordinator": usage_coordinator,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/launtel/api.py
+++ b/custom_components/launtel/api.py
@@ -14,6 +14,30 @@ __all__ = ["LauntelClient", "LauntelService"]
 BASE_URL = URL("https://residential.launtel.net.au")
 
 
+def _echarts_series(html: str, name: str) -> list[Optional[float]]:
+    """Extract an ECharts series' numeric ``data`` array by its ``name:'...'``.
+
+    The /usage page renders the monthly usage graph as an inline ECharts option
+    object rather than exposing a separate JSON endpoint. Each daily bar/line is
+    a quoted string (e.g. '87.51'); the 30-day-average line contains 'null'
+    entries which are returned as ``None``.
+    """
+    i = html.find(f"name:'{name}'")
+    if i == -1:
+        return []
+    start = html.find("[", html.find("data:", i))
+    end = html.find("]", start)
+    if start == -1 or end == -1:
+        return []
+    out: list[Optional[float]] = []
+    for tok in re.findall(r"'([^']*)'", html[start:end + 1]):
+        try:
+            out.append(float(tok.strip()))
+        except ValueError:
+            out.append(None)
+    return out
+
+
 @dataclass
 class LauntelService:
     title: str
@@ -74,7 +98,7 @@ class LauntelClient:
             serv_avc_id = card.get("id", "")
 
             # Extract service_id from onclick handler (pauseService/unpauseService)
-            pause_button = card.find("button", onclick=re.compile(r"(un)?pauseService\((\d+)") )
+            pause_button = card.find("button", onclick=re.compile(r"(un)?pauseService\((\d+)"))
             serv_id: Optional[int] = None
             if pause_button and pause_button.has_attr("onclick"):
                 m = re.search(r"(un)?pauseService\((\d+)", pause_button["onclick"])
@@ -265,9 +289,9 @@ class LauntelClient:
         resp.raise_for_status()
         html = await resp.text()
         soup = BeautifulSoup(html, "html.parser")
-        
+
         balance = None
-        
+
         # Look for the specific current balance structure
         # Target: <dt>Current Balance</dt><dd><span>+$112.65</span></dd>
         # Note: dt may contain nested HTML elements, so we need to search by text content
@@ -277,7 +301,7 @@ class LauntelClient:
             if re.search(r"Current\s+Balance", dt.get_text(), re.I):
                 balance_dt = dt
                 break
-        
+
         if balance_dt:
             dd_balance = balance_dt.find_next("dd")
             if dd_balance:
@@ -285,7 +309,7 @@ class LauntelClient:
                 balance_span = dd_balance.find("span")
                 if balance_span:
                     balance_text = balance_span.get_text(strip=True)
-                    
+
                     # Extract numeric value from text like '+$112.65' or '-$50.00'
                     balance_match = re.search(r'([\+\-]?)\$?([0-9,]+\.?[0-9]*)', balance_text)
                     if balance_match:
@@ -296,7 +320,7 @@ class LauntelClient:
                             balance = -balance if sign == '-' else balance
                         except (ValueError, AttributeError):
                             balance = None
-        
+
         return balance
 
     async def async_get_estimated_days_remaining(self) -> Optional[int]:
@@ -306,9 +330,9 @@ class LauntelClient:
         resp.raise_for_status()
         html = await resp.text()
         soup = BeautifulSoup(html, "html.parser")
-        
+
         days_remaining = None
-        
+
         # Look for the specific estimated days remaining structure
         # Target: <dt>Estimated Days Remaining ... </dt><dd><span class="text-success">27</span></dd>
         # Note: dt may contain nested HTML elements, so we need to search by text content
@@ -318,7 +342,7 @@ class LauntelClient:
             if re.search(r"Estimated\s+Days\s+Remaining", dt.get_text(), re.I):
                 days_dt = dt
                 break
-        
+
         if days_dt:
             dd_days = days_dt.find_next("dd")
             if dd_days:
@@ -326,7 +350,7 @@ class LauntelClient:
                 days_span = dd_days.find("span")
                 if days_span:
                     days_text = days_span.get_text(strip=True)
-                    
+
                     # Extract numeric value from text like "27"
                     days_match = re.search(r'(\d+)', days_text)
                     if days_match:
@@ -334,5 +358,72 @@ class LauntelClient:
                             days_remaining = int(days_match.group(1))
                         except (ValueError, AttributeError):
                             days_remaining = None
-        
+
         return days_remaining
+
+    async def async_get_usage(self, user_id: str, day: int = 1) -> Optional[dict]:
+        """Scrape today's and month-to-date data usage (GB) from /usage.
+
+        The monthly graph is rendered inline as an ECharts option. Daily values
+        live in per-series ``data`` arrays keyed by name:
+          - 'Data Usage Down'
+          - 'Data Usage Up'
+          - 'Data Usage Night (Free)'  (absent on plans without a free-night tier)
+        The chart title carries the authoritative month-to-date total.
+
+        ``day`` is the local day-of-month (1-31); the value at index day-1 is
+        today's bar. Days later in the month read 0.00 until they arrive.
+
+        Returns a dict of GB figures, or None if the page couldn't be parsed
+        (so the caller can keep the last known values).
+        """
+        await self._ensure_login()
+
+        async def _fetch() -> str:
+            resp = await self._session.get(BASE_URL / "usage", params={"userid": str(user_id)})
+            resp.raise_for_status()
+            return await resp.text()
+
+        html = await _fetch()
+
+        # Session cookie may have lapsed during long-running polling; the portal
+        # then serves the login page. Re-authenticate once and retry.
+        if 'name="username"' in html:
+            self._logged_in = False
+            await self.async_login()
+            html = await _fetch()
+
+        down = _echarts_series(html, "Data Usage Down")
+        up = _echarts_series(html, "Data Usage Up")
+        night = _echarts_series(html, "Data Usage Night (Free)")
+
+        if not down and not up:
+            # Page layout changed or usage not yet available; signal "no data".
+            return None
+
+        idx = day - 1
+
+        def _at(series: list[Optional[float]]) -> float:
+            if 0 <= idx < len(series) and series[idx] is not None:
+                return float(series[idx])
+            return 0.0
+
+        d, u, n = _at(down), _at(up), _at(night)
+
+        # Month-to-date total: prefer the chart title (matches the portal exactly),
+        # fall back to summing the daily series.
+        m = re.search(r"Total Usage\s*([\d.]+)\s*GB", html)
+        if m:
+            month_total = float(m.group(1))
+        else:
+            month_total = round(
+                sum(v for v in (down + up + night) if v is not None), 2
+            )
+
+        return {
+            "today_gb": round(d + u + n, 2),
+            "download_gb": round(d, 2),
+            "upload_gb": round(u, 2),
+            "night_free_gb": round(n, 2),
+            "month_to_date_gb": round(month_total, 2),
+        }

--- a/custom_components/launtel/sensor.py
+++ b/custom_components/launtel/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.const import CURRENCY_DOLLAR, UnitOfTime
+from homeassistant.const import CURRENCY_DOLLAR, UnitOfInformation, UnitOfTime
 
 from .const import DOMAIN
 
@@ -16,11 +16,16 @@ from .const import DOMAIN
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
+    usage_coordinator = data["usage_coordinator"]
 
     entities = [
         LauntelCurrentPlanSensor(coordinator, entry),
         LauntelBalanceSensor(coordinator, entry),
         LauntelEstimatedDaysRemainingSensor(coordinator, entry),
+        LauntelUsageTodaySensor(usage_coordinator, entry),
+        LauntelUsageTodayDownloadSensor(usage_coordinator, entry),
+        LauntelUsageTodayUploadSensor(usage_coordinator, entry),
+        LauntelUsageMonthSensor(usage_coordinator, entry),
     ]
     async_add_entities(entities)
 
@@ -116,13 +121,13 @@ class LauntelBalanceSensor(CoordinatorEntity, SensorEntity):
         attrs: dict[str, Any] = {
             "last_updated": self.coordinator.last_update_success,
         }
-        
+
         if balance is not None:
             attrs.update({
                 "balance_status": "credit" if balance >= 0 else "debt",
                 "formatted_balance": f"${abs(balance):.2f}",
             })
-        
+
         return attrs
 
 
@@ -162,11 +167,107 @@ class LauntelEstimatedDaysRemainingSensor(CoordinatorEntity, SensorEntity):
         attrs: dict[str, Any] = {
             "last_updated": self.coordinator.last_update_success,
         }
-        
+
         if days_remaining is not None:
             attrs.update({
                 "status": "low" if days_remaining < 7 else "normal",
                 "weeks_remaining": round(days_remaining / 7, 1),
             })
-        
+
         return attrs
+
+
+class _LauntelUsageBase(CoordinatorEntity, SensorEntity):
+    """Shared config for usage sensors (backed by the usage coordinator)."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.DATA_SIZE
+    _attr_native_unit_of_measurement = UnitOfInformation.GIGABYTES
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_suggested_display_precision = 2
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self._entry.data["service_id"]))},
+            name=self._entry.title,
+            manufacturer="Launtel",
+            model="Internet Service",
+        )
+
+
+class LauntelUsageTodaySensor(_LauntelUsageBase):
+    """Total data used today (download + upload + free-night, in GB)."""
+
+    _attr_icon = "mdi:swap-vertical"
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_name = f"{entry.title} usage today"
+        self._attr_unique_id = f"{entry.data['service_id']}_usage_today"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        return data.get("today_gb")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        data = self.coordinator.data or {}
+        return {
+            "download_gb": data.get("download_gb"),
+            "upload_gb": data.get("upload_gb"),
+            "night_free_gb": data.get("night_free_gb"),
+        }
+
+
+class LauntelUsageTodayDownloadSensor(_LauntelUsageBase):
+    """Data downloaded today (GB)."""
+
+    _attr_icon = "mdi:download-network"
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_name = f"{entry.title} download today"
+        self._attr_unique_id = f"{entry.data['service_id']}_usage_today_download"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        return data.get("download_gb")
+
+
+class LauntelUsageTodayUploadSensor(_LauntelUsageBase):
+    """Data uploaded today (GB)."""
+
+    _attr_icon = "mdi:upload-network"
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_name = f"{entry.title} upload today"
+        self._attr_unique_id = f"{entry.data['service_id']}_usage_today_upload"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        return data.get("upload_gb")
+
+
+class LauntelUsageMonthSensor(_LauntelUsageBase):
+    """Month-to-date total data usage (GB), as reported by the portal."""
+
+    _attr_icon = "mdi:calendar-month"
+
+    def __init__(self, coordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_name = f"{entry.title} usage this month"
+        self._attr_unique_id = f"{entry.data['service_id']}_usage_month"
+
+    @property
+    def native_value(self) -> float | None:
+        data = self.coordinator.data or {}
+        return data.get("month_to_date_gb")


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Add daily data usage sensors (today up/down, month-to-date)</h2>
<h3>Summary</h3>
<p>Adds data usage monitoring to the integration by scraping the portal's <code>/usage</code> page. This exposes how much data the service has used today and month-to-date, so usage can be tracked, graphed, and used in automations (e.g. notify when approaching a quota).</p>
<p>No new configuration is required — the <code>/usage</code> page is keyed on <code>user_id</code>, which is already captured in the config entry during setup.</p>
<h3>New entities</h3>
<p>Attached to the existing service device:</p>

Entity | Description | Unit / class
-- | -- | --
..._usage_today | Total data used today (download + upload + free-night) | GB · data_size · total_increasing
..._usage_today_download | Downloaded today | GB · data_size · total_increasing
..._usage_today_upload | Uploaded today | GB · data_size · total_increasing
..._usage_month | Month-to-date total, as reported by the portal | GB · data_size · total_increasing


<p>The combined "today" sensor also carries <code>download_gb</code>, <code>upload_gb</code>, and <code>night_free_gb</code> as attributes.</p>
<h3>How it works</h3>
<p>The <code>/usage</code> page renders its monthly graph as an inline ECharts option object rather than exposing a separate JSON endpoint, so the daily figures are parsed directly out of the returned HTML. <code>_echarts_series()</code> locates each series by its <code>name:'...'</code> and returns the daily <code>data</code> array; today's value is the entry at index <code>day - 1</code> (using Home Assistant's local date so the day-of-month lines up with the portal's month buckets). The month-to-date total is read from the chart title, which matches the portal's own figure exactly, with a fall-back that sums the daily series.</p>
<p>Series are matched by name, not by position, so plans without a free-night tier (where the <code>Data Usage Night (Free)</code> series isn't rendered) are handled gracefully and will pick up the tier automatically if it later appears.</p>
<h3>Design notes</h3>
<ul>
<li><strong>Dedicated coordinator.</strong> Usage polls on its own <code>DataUpdateCoordinator</code> at a 30-minute interval, decoupled from the existing plan/balance coordinator (6h normal / 1m during plan changes). Launtel's usage figure updates stepwise through the day rather than live, so a tighter-but-gentle cadence captures changes without hammering the portal.</li>
<li><strong>Non-blocking setup.</strong> The first usage refresh uses <code>async_refresh()</code> (not <code>async_config_entry_first_refresh()</code>), so a transient usage-scrape failure at startup can't block the rest of the integration from loading — the usage sensors simply start unavailable and recover on the next poll.</li>
<li><strong>Session resilience.</strong> <code>async_get_usage()</code> detects an expired session (the portal serving the login page) and re-authenticates once before retrying, which keeps the long-running usage poll alive.</li>
<li><strong><code>total_increasing</code></strong> is used so today's value (which climbs during the day and resets at midnight) and the month-to-date total (which resets on the 1st) both produce clean long-term statistics.</li>
</ul>
<h3>Changes</h3>
<ul>
<li><code>api.py</code> — add <code>_echarts_series()</code> helper and <code>async_get_usage()</code>. No new dependencies (parsing uses <code>re</code>; <code>beautifulsoup4</code> is unchanged).</li>
<li><code>__init__.py</code> — add the usage coordinator and store it on the entry.</li>
<li><code>sensor.py</code> — add the four usage sensor entities.</li>
</ul>
<p>No changes to the config flow, and no breaking changes to existing entities or their unique IDs.</p>
<h3>Testing</h3>
<ul>
<li>Parser verified against a real logged-in <code>/usage</code> page; today's up/down and the month-to-date total match the values shown in the portal.</li>
<li>Verified on a running Home Assistant instance: the new sensors appear after a restart with no need to remove/re-add the integration, and populate on the first successful poll.</li>
</ul>
<h3>Notes / limitations</h3>
<ul>
<li>Usage granularity is bounded by the portal (daily, updated periodically), so values move in steps rather than continuously.</li>
<li>This scrapes an unofficial portal page; the parser is defensive but could need updating if Launtel changes the usage page markup.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>